### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -87,7 +87,7 @@ library
                       , semigroups         == 0.18.* || == 0.19.*
   build-depends:        array              >= 0.4 && < 0.6
                       , base               >= 4.5 && < 4.15
-                      , bytestring         >= 0.9.2 && < 0.11
+                      , bytestring         >= 0.9.2 && < 0.12
                       , containers         >= 0.4.2 && < 0.7
                       , mtl                >= 2.1.3 && < 2.3
                       , parsec             == 3.1.*


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: True

constraints:
  bytestring >= 0.11

allow-newer:
  regex-base:bytestring
```