### PR TITLE
Fix #23: remove NoMonoPatBinds

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210220
+# version: 0.13.20210526
 #
-# REGENDATA ("0.11.20210220",["github","regex-tdfa.cabal"])
+# REGENDATA ("0.13.20210526",["github","regex-tdfa.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,7 +18,7 @@ on:
   - pull_request
 jobs:
   linux:
-    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
@@ -26,27 +26,27 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 9.0.1
+          - compiler: ghc-9.0.1
             allow-failure: false
-          - ghc: 8.10.4
+          - compiler: ghc-8.10.4
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-8.8.4
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-8.6.5
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-8.4.4
             allow-failure: false
-          - ghc: 8.2.2
+          - compiler: ghc-8.2.2
             allow-failure: false
-          - ghc: 8.0.2
+          - compiler: ghc-8.0.2
             allow-failure: false
-          - ghc: 7.10.3
+          - compiler: ghc-7.10.3
             allow-failure: false
-          - ghc: 7.8.4
+          - compiler: ghc-7.8.4
             allow-failure: false
-          - ghc: 7.6.3
+          - compiler: ghc-7.6.3
             allow-failure: false
-          - ghc: 7.4.2
+          - compiler: ghc-7.4.2
             allow-failure: false
       fail-fast: false
     steps:
@@ -56,29 +56,31 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
+          apt-get install -y $CC cabal-install-3.4
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          CC: ${{ matrix.compiler }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
           echo "LANG=C.UTF-8" >> $GITHUB_ENV
           echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
+          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
+          HCNAME=ghc
+          HC=$HCDIR/bin/$HCNAME
           echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
+          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
+          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
           echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
           echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
+          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          CC: ${{ matrix.compiler }}
       - name: env
         run: |
           env
@@ -157,9 +159,9 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 See also http://pvp.haskell.org/faq
 
-## 1.3.1.0 Revision 2
+## 1.3.1.1 (2021-06-02)
+
+- Removed extension NoMonoPatBinds from `.cabal`-file for GHC 9.2 compatibility.
+
+## 1.3.1.0 Revision 2 (2021-02-20)
 
 - Compatibility with `base-4.15` (GHC 9.0) and `bytestring-0.11`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,88 +1,107 @@
-See also http://pvp.haskell.org/faq
+For the package version policy (PVP), see  http://pvp.haskell.org/faq .
 
-## 1.3.1.1 (2021-06-02)
+### 1.3.1.1
 
-- Removed extension NoMonoPatBinds from `.cabal`-file for GHC 9.2 compatibility.
+_2021-06-03, Andreas Abel_
+- Removed extension `NoMonoPatBinds` from `.cabal`-file for GHC 9.2 compatibility.
+- Removed some outdated documentation.
 
-## 1.3.1.0 Revision 2 (2021-02-20)
+### 1.3.1.0 Revision 2
 
+_2021-02-20, Andreas Abel_
 - Compatibility with `base-4.15` (GHC 9.0) and `bytestring-0.11`
+
+### 1.3.1.0 Revision 1
+
+_2020-03-26, phadej_
+- Compatibility with `base-4.14` (GHC 8.10)
 
 ## 1.3.1.0
 
+_2019-11-26, hvr_
 - Merge <http://hackage.haskell.org/package/regex-tdfa-text> into `regex-tdfa`; see <https://github.com/haskell-hvr/regex-tdfa/issues/4>.
 - Don't inject `ghc-options: -O2` by default anymore (see #7 for rationale) and introduce `force-O2` cabal flag to control the injection of `ghc-options: -O2`.
   Note that you can conveniently control optimization levels on a per-package granularity via `cabal.project` files; see [cabal's user-guide](https://cabal.readthedocs.io/en/latest/nix-local-build.html#configuring-builds-with-cabal-project) for more details.
 
+## 1.3.0 Revision 1
+
+_2019-11-26, hvr_
+- Tighten bounds on `base`, `mtl`, `parsec` and fail.
+
 # 1.3.0
 
-- Same as 1.2.3.3 release; see <https://github.com/ChrisKuklewicz/regex-tdfa/issues/29>.
+_2019-09-29, Artyom_
+- Same as 1.2.3.3 release, but in accordance to PVP;
+  see <https://github.com/ChrisKuklewicz/regex-tdfa/issues/29>.
 - Compatibility with GHC 8.8 and regex-base-0.9.4 (h/t @asr).
 - Turned `regex-tdfa-unittest` into a `regex-tdfa` testsuite.
 
-----
-
-### 1.2.3.3 (deprecated)
+### 1.2.3.3 (deprecated, not following PVP)
 
 * Compatibility with GHC 8.8 and regex-base-0.9.4 (h/t @asr).
 * Turned `regex-tdfa-unittest` into a `regex-tdfa` testsuite.
 
 ### 1.2.3.2
 
+_2019-05-09, Artyom_
 * Significantly improved documentation (h/t William Yao).
 
 ### 1.2.3.1
 
+_2018-06-22, Artyom_
 * Compatibility with `containers-0.6`.
 
 ## 1.2.3
 
+_2018-03-10, Artyom_
 * Added `Semigroup` instances for some types (h/t Herbert Valerio Riedel).
 
 ## 1.2.2
 
+_2016-04-28, Artyom_
 * New maintainer.
 * Now we don't reexport the problematic `Show` instance for functions.
 
 ## 1.2.1
 
+_2015-08-29, Chris Kuklewicz_
 * Updated dependency versions.
 
 # 1.2.0
 
-"Almost ghc-7.8" with the array 0.4 changes for `Data.Array.Unsafe`
+_2014-02-02, Chris Kuklewicz_
+* "Almost ghc-7.8" with the array 0.4 changes for `Data.Array.Unsafe`
 
-----
 
-# 1.1.8
+## 1.1.8
 
 Make ghc-7.0.2 on platorm 2011.2.0.0.0 happy
 
-# 1.1.7
+## 1.1.7
 
 fix url below
 
-# 1.1.6
+## 1.1.6
 
 Fix bug preventing `[]] [-] [^]] [^-]` (thanks to Maxime Henrion)
 
-# 1.1.5
+## 1.1.5
 
 try `needUniqTags` in `POr` in CorePattern.hs, try `toAdvice b` for `PStar child`
 
-# 1.1.4
+## 1.1.4
 
 fixed
 
-# 1.1.3
+## 1.1.3
 
 BROKEN after 100 characters the `compressOrbit` dies!
 
-# 1.1.2
+## 1.1.2
 
 worked
 
-# 1.1.1
+## 1.1.1
 
 add gnu escapes
 
@@ -90,19 +109,19 @@ add gnu escapes
 
 NewDFA code working
 
-# 1.0.7
+## 1.0.7
 
 make NewDFA directory and String_NC
 
-# 1.0.6
+## 1.0.6
 
 try NewDFATest_SBS with `uncons`
 
-# 1.0.5
+## 1.0.5
 
 use `uncons` on SBS
 
-# 1.0.4
+## 1.0.4
 
 try repaired NewDFATest_SBS
 
@@ -119,11 +138,11 @@ try repaired NewDFATest_SBS
 * np3:  `!off` the multi? No
 * np2:  comment out all Testing code? No
 
-# 1.0.3
+## 1.0.3
 
 try to alter `matchTest` to not have the `Bool` args? No
 
-# 1.0.2
+## 1.0.2
 
 arg, the prof is fast and the normal slow!
 
@@ -131,70 +150,70 @@ arg, the prof is fast and the normal slow!
 
 add NewDFATest.hs
 
-# 0.99.20
+## 0.99.20
 
 go to many vs single?
 
-# 0.99.19
+## 0.99.19
 
 try for pre-comparison of orbit-logs!
 
-# 0.99.18
+## 0.99.18
 
 try alternate lazy/strict strategy in NewDFA. Fix offset laziness.
 
-# 0.99.17
+## 0.99.17
 
 radical removal of flag array and adding of `SetVal` to handle groups
 
-# 0.99.16
+## 0.99.16
 
 performance? up to v15
 
-# 0.99.15
+## 0.99.15
 
 get string with NewDFA testing, unit tests and 1000 random regex pass
 
-# 0.99.14
+## 0.99.14
 
 start changing to the new real DFA
 
-# 0.99.13
+## 0.99.13
 
 more cleanup
 
-# 0.99.12
+## 0.99.12
 
 try to debug 0.99.11: fixed `updateWinner`
 
-# 0.99.11
+## 0.99.11
 
 improve above fix and make stuff work better – HAS BUG, along with old TDFA!
 
-# 0.99.10
+## 0.99.10
 
 fixed `((.?)*)*` patterns by changing `PStar nullView` when `mayFirstBeNull`
 
-# 0.99.9
+## 0.99.9
 
 testing changing `bestTrans`/`chooseWith`/`choose` to include `enterOrbit`/`newFlags`/`(_,True)` info
 
-# 0.99.8
+## 0.99.8
 
 testing changing `Maximize` to `Minimize` for `Tag`s, decide `(a*)*` is canonical problem
 
-# 0.99.7
+## 0.99.7
 
 Use `(PGroup Nothing)` in `Pattern` to decompose `PBound`
 
-# 0.99.6
+## 0.99.6
 
 change to nested `nonEmpty` calls for `PBound`
 
-# 0.99.5
+## 0.99.5
 
 remove `PNonEmpty` constructor
 
-# 0.99.4
+## 0.99.4
 
 tests `pnonempty' = \ p -> POr [ PEmpty, p ]` instead of `PNonEmpty`

--- a/lib/Text/Regex/TDFA.hs
+++ b/lib/Text/Regex/TDFA.hs
@@ -2,7 +2,8 @@
 Module: Text.Regex.TDFA
 Copyright: (c) Chris Kuklewicz 2007-2009
 SPDX-License-Identifier: BSD-3-Clause
-Maintainer: hvr@gnu.org
+Maintainer: hvr@gnu.org, Andreas Abel
+Stability: stable
 
 The "Text.Regex.TDFA" module provides a backend for regular
 expressions. It provides instances for the classes defined and
@@ -18,7 +19,7 @@ OS's bugs.
 
 = Importing and using
 
-<https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-build-depends Declare a dependency> on the @regex-tdfa@ library in your @.cabal@ file:
+Declare a dependency on the @regex-tdfa@ library in your @.cabal@ file:
 
 > build-depends: regex-tdfa ^>= 1.3.1.1
 
@@ -117,10 +118,7 @@ This package does provide captured parenthesized subexpressions.
 
 Depending on the text being searched this package supports Unicode.
 The @[Char]@, @Text@, @Text.Lazy@, and @(Seq Char)@ text types support Unicode.  The @ByteString@
-and @ByteString.Lazy@ text types only support ASCII.  It is possible to
-support utf8 encoded @ByteString.Lazy@ by using regex-tdfa and
-<http://hackage.haskell.org/package/regex-tdfa-utf8 regex-tdfa-utf8>
-packages together (required the utf8-string package).
+and @ByteString.Lazy@ text types only support ASCII.
 
 As of version 1.1.1 the following GNU extensions are recognized, all
 anchors:

--- a/lib/Text/Regex/TDFA.hs
+++ b/lib/Text/Regex/TDFA.hs
@@ -20,7 +20,7 @@ OS's bugs.
 
 <https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-build-depends Declare a dependency> on the @regex-tdfa@ library in your @.cabal@ file:
 
-> build-depends: regex-tdfa ^>= 1.3.1.0
+> build-depends: regex-tdfa ^>= 1.3.1.1
 
 In Haskell modules where you want to use regexes simply @import@ /this/ module:
 

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -1,7 +1,6 @@
 cabal-version:          1.12
 name:                   regex-tdfa
-version:                1.3.1.0
-x-revision:             2
+version:                1.3.1.1
 
 build-Type:             Simple
 license:                BSD3
@@ -27,7 +26,6 @@ extra-source-files:
   test/cases/*.txt
 
 tested-with:
-  -- Haskell CI:
   GHC == 7.4.2
   GHC == 7.6.3
   GHC == 7.8.4
@@ -47,7 +45,7 @@ source-repository head
 source-repository this
   type:                git
   location:            https://github.com/hvr/regex-tdfa.git
-  tag:                 v1.3.1.0-r2
+  tag:                 v1.3.1.1
 
 flag force-O2
   default: False
@@ -116,7 +114,6 @@ library
                         FunctionalDependencies
                         MagicHash
                         MultiParamTypeClasses
-                        NoMonoPatBinds
                         NondecreasingIndentation
                         RecursiveDo
                         TypeOperators


### PR DESCRIPTION
Fix #23: remove NoMonoPatBinds

Release this as 1.3.1.1.
The base dependency for ghc-9.2 can then be bumped in a revision.