### PR TITLE
Mention getAllMatches is non-overlapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ a =~ b :: (String, String, String, [String])
 >>> ("", "div[attr=1234]", "", ["attr","1234"])
 ```
 
-#### Get *all* matches
+#### Get *all* non-overlapping matches
 
 ```haskell
 -- can also return Data.Array instead of List


### PR DESCRIPTION
Recently I wasted a substantial amount of time due to credulously assuming "getAllMatches" meant "get all matches." Reflecting on this it seems a very small change to the documentation would have been helpful. If there's interest in this please accept. Thanks. 