### PR TITLE
Remove uses of `MonadFail (ST _)`

### DIFF
--- a/lib/Data/IntMap/EnumMap2.hs
+++ b/lib/Data/IntMap/EnumMap2.hs
@@ -50,7 +50,7 @@ notMember k (EnumMap m) = M.notMember (fromEnum k) m
 
 {-# INLINE lookup #-}
 lookup :: (Enum key) => key -> EnumMap key a -> Maybe a
-lookup k (EnumMap m) = maybe (fail "EnumMap.lookup failed") return $ M.lookup (fromEnum k) m
+lookup k (EnumMap m) = M.lookup (fromEnum k) m
 
 findWithDefault :: (Enum key) => a -> key -> EnumMap key a -> a
 findWithDefault a k (EnumMap m) = M.findWithDefault a (fromEnum k) m

--- a/lib/Text/Regex/TDFA/NewDFA/Engine.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine.hs
@@ -285,7 +285,8 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
                     challenge x1@((_si1,ins1),_p1,_o1) x2@((_si2,ins2),_p2,_o2) = {-# SCC "goNext.findTrans.challenge" #-} do
                       check <- comp offset x1 (newPos ins1) x2 (newPos ins2)
                       if check==LT then return x2 else return x1
-                (first:rest) <- mapM prep (IMap.toList sources)
+                first_rest <- mapM prep (IMap.toList sources)
+                let first:rest = first_rest
                 set which destIndex =<< foldM challenge first rest
           let dl = IMap.toList dtrans
           mapM_ findTransTo dl

--- a/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
@@ -240,7 +240,8 @@ execMatch (Regex { regex_dfa =  DFA {d_id=didIn,d_dt=dtIn}
                     challenge x1@((_si1,ins1),_p1,_o1) x2@((_si2,ins2),_p2,_o2) = {-# SCC "goNext.findTrans.challenge" #-} do
                       check <- comp offset x1 (newPos ins1) x2 (newPos ins2)
                       if check==LT then return x2 else return x1
-                (first:rest) <- mapM prep (IMap.toList sources)
+                first_rest <- mapM prep (IMap.toList sources)
+                let first:rest = first_rest
                 set which destIndex =<< foldM challenge first rest
           let dl = IMap.toList dtrans
           mapM_ findTransTo dl

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -118,6 +118,7 @@ library
                         MultiParamTypeClasses
                         NondecreasingIndentation
                         RecursiveDo
+                        ScopedTypeVariables
                         TypeOperators
                         TypeSynonymInstances
                         UnboxedTuples
@@ -125,6 +126,9 @@ library
   other-extensions:     CPP
 
   ghc-options:          -Wall -funbox-strict-fields -fspec-constr-count=10 -fno-warn-orphans
+
+  if impl(ghc >= 8.0)
+    ghc-options:        -Wcompat
 
   if flag(force-O2)
     ghc-options:        -O2
@@ -164,6 +168,9 @@ test-suite regex-tdfa-unittest
   other-extensions:     GeneralizedNewtypeDeriving
 
   ghc-options:          -Wall -funbox-strict-fields
+
+  if impl(ghc >= 8.0)
+    ghc-options:        -Wcompat
 
   if flag(force-O2)
     ghc-options:        -O2


### PR DESCRIPTION
haskell/core-libraries-committee#33 : Remove uses of `MonadFail (ST _)`

Also:
- There was a use of `fail` for `Maybe` which is entirely pointless.
- Type signatures for some local functions in `NewDFA/Engine_FA`