### PR TITLE
Release 1.3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,27 @@ For the package version policy (PVP), see  http://pvp.haskell.org/faq .
 
 ### 1.3.1.2
 
-_Unreleased_
-- No longer rely on the `MonadFail` instance for `ST`.
-  [#29](https://github.com/haskell-hvr/regex-tdfa/pull/29)
+_2022-02-19, Andreas Abel_
+- No longer rely on the `MonadFail` instance for `ST`
+  (future `base` library change, see [#29](https://github.com/haskell-hvr/regex-tdfa/pull/29)).
 - Silence warning `incomplete-uni-patterns` (GHC >= 9.2).
-- Import `Data.List` qualified.
-- Import from `Control.Monad` directly for future `mtl` compatibility.
+- Import from `Data.List` explicitly or qualified (warning `compat-unqualified-imports`).
+- Import from `Control.Monad` to allow `mtl-2.3` in its `rc3` incarnation.
 
 ### 1.3.1.1 Revision 3
 
 _2022-01-31, Andreas Abel_
-- Allow `mtl-2.3`.
+- Speculatively allow unreleased `mtl-2.3` (works with release candidate `mtl-2.3-rc4`).
 
 ### 1.3.1.1 Revision 2
 
 _2021-12-26, Andreas Abel_
-- Allow `text-2.0`
+- Allow `text-2.0`.
 
 ### 1.3.1.1 Revision 1
 
 _2021-08-12, Andreas Abel_
-- Compatibility with `base-4.16` (GHC 9.2)
+- Compatibility with `base-4.16` (GHC 9.2).
 
 ### 1.3.1.1
 
@@ -33,12 +33,12 @@ _2021-06-03, Andreas Abel_
 ### 1.3.1.0 Revision 2
 
 _2021-02-20, Andreas Abel_
-- Compatibility with `base-4.15` (GHC 9.0) and `bytestring-0.11`
+- Compatibility with `base-4.15` (GHC 9.0) and `bytestring-0.11`.
 
 ### 1.3.1.0 Revision 1
 
 _2020-03-26, phadej_
-- Compatibility with `base-4.14` (GHC 8.10)
+- Compatibility with `base-4.14` (GHC 8.10).
 
 ## 1.3.1.0
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This was also documented at the [Haskell wiki](https://wiki.haskell.org/Regular_
 
 Then the repository moved to <https://github.com/ChrisKuklewicz/regex-tdfa>, which was primarily maintained by [Artyom (neongreen)](https://github.com/neongreen).
 
-Finally, maintainership was passed on again and the repository moved to its current location at <https://github.com/hvr/regex-tdfa>.
+Finally, maintainership was passed on again and the repository moved to its current location at <https://github.com/haskell-hvr/regex-tdfa>.
 
 ## Avoiding backslashes
 
@@ -182,8 +182,8 @@ import Text.Regex.TDFA
 
 * POSIX submatch semantics are broken in some rare cases ([#2][]).
 
-[#2]: https://github.com/hvr/regex-tdfa/issues/2
-[#3]: https://github.com/hvr/regex-tdfa/issues/3
+[#2]: https://github.com/haskell-hvr/regex-tdfa/issues/2
+[#3]: https://github.com/haskell-hvr/regex-tdfa/issues/3
 
 ## About this package
 

--- a/lib/Text/Regex/TDFA.hs
+++ b/lib/Text/Regex/TDFA.hs
@@ -2,7 +2,7 @@
 Module: Text.Regex.TDFA
 Copyright: (c) Chris Kuklewicz 2007-2009
 SPDX-License-Identifier: BSD-3-Clause
-Maintainer: hvr@gnu.org, Andreas Abel
+Maintainer: Andreas Abel
 Stability: stable
 
 The "Text.Regex.TDFA" module provides a backend for regular

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -7,11 +7,9 @@ license:                BSD3
 license-file:           LICENSE
 copyright:              Copyright (c) 2007-2009, Christopher Kuklewicz
 author:                 Christopher Kuklewicz
-maintainer:
-  Herbert Valerio Riedel <hvr@gnu.org>,
-  Andreas Abel
+maintainer:             Andreas Abel
 homepage:               https://wiki.haskell.org/Regular_expressions
-bug-reports:            https://github.com/hvr/regex-tdfa/issues
+bug-reports:            https://github.com/haskell-hvr/regex-tdfa/issues
 
 category:               Text
 synopsis:               Pure Haskell Tagged DFA Backend for "Text.Regex" (regex-base)
@@ -42,11 +40,11 @@ tested-with:
 
 source-repository head
   type:                git
-  location:            https://github.com/hvr/regex-tdfa.git
+  location:            https://github.com/haskell-hvr/regex-tdfa.git
 
 source-repository this
   type:                git
-  location:            https://github.com/hvr/regex-tdfa.git
+  location:            https://github.com/haskell-hvr/regex-tdfa.git
   tag:                 v1.3.1.2
 
 flag force-O2


### PR DESCRIPTION
- Works with both RC4 and RC3 of `mtl-2.3`
- Finalized CHANGELOG for 1.3.1.2

Candidate at: https://hackage.haskell.org/package/regex-tdfa-1.3.1.2/candidate