### PR TITLE
fix typos

### DIFF
--- a/lib/Text/Regex/TDFA/Common.hs
+++ b/lib/Text/Regex/TDFA/Common.hs
@@ -94,7 +94,7 @@ data CompOption = CompOption {
   , newSyntax :: Bool        -- ^ False in blankCompOpt, True in defaultCompOpt. Add the extended non-POSIX syntax described in "Text.Regex.TDFA" haddock documentation.
   , lastStarGreedy ::  Bool  -- ^ False by default.  This is POSIX correct but it takes space and is slower.
                             -- Setting this to true will improve performance, and should be done
-                            -- if you plan to set the captureGroups execoption to False.
+                            -- if you plan to set the captureGroups exeception to False.
   } deriving (Read,Show)
 
 data ExecOption = ExecOption {
@@ -226,7 +226,7 @@ data DT = Simple' { dt_win :: IntMap {- Source Index -} Instructions -- ^ Action
                    , dt_a,dt_b :: DT      -- ^ use dt_a if test is True else use dt_b
                    }
 
--- | Internal type to repesent the commands for the tagged transition.
+-- | Internal type to represent the commands for the tagged transition.
 -- The outer IntMap is for the destination Index and the inner IntMap
 -- is for the Source Index.  This is convenient since all runtime data
 -- going to the same destination must be compared to find the best.

--- a/lib/Text/Regex/TDFA/CorePattern.hs
+++ b/lib/Text/Regex/TDFA/CorePattern.hs
@@ -269,7 +269,7 @@ cannotAccept q = maybe False (0==) $ snd . takes $ q
 -- favoring pushing Apply into the child postTag makes PGroup happier
 
 type PM = RWS (Maybe GroupIndex) [Either Tag GroupInfo] ([OP]->[OP],Tag)
-type HHQ = HandleTag  -- m1 : info about left boundaary / preTag
+type HHQ = HandleTag  -- m1 : info about left boundary / preTag
         -> HandleTag  -- m2 : info about right boundary / postTag
         -> PM Q
 
@@ -389,7 +389,7 @@ patternToQ compOpt (pOrig,(maxGroupIndex,_)) = (tnfa,aTags,aGroups) where
 
   -- combineConcat is a partial function: Must not pass in an empty list
   -- Policy choices:
-  --  * pass tags to apply to children and have no preTag or postTag here (so none addded to nullQ)
+  --  * pass tags to apply to children and have no preTag or postTag here (so none added to nullQ)
   --  * middle 'mid' tag: give to left/front child as postTag so a Group there might claim it as a stopTag
   --  * if parent is Group then preReset will become non-empty
   combineConcat :: [Pattern] -> HHQ
@@ -465,7 +465,7 @@ patternToQ compOpt (pOrig,(maxGroupIndex,_)) = (tnfa,aTags,aGroups) where
                newUniq = if needUniqTags then uniq "POr branch" else return bAdvice
 --           trace ("\nPOr sub "++show aAdvice++" "++show bAdvice++"needsTags is "++show needTags) $ return ()
            -- The "bs" values are allocated in left-to-right order before the children in "qs"
-           -- optimiztion: low priority for last branch is implicit, do not create separate tag here.
+           -- optimization: low priority for last branch is implicit, do not create separate tag here.
            bs <- fmap (++[bAdvice]) $ replicateM (pred $ length branches) newUniq -- 2 <= length ps
            -- create all the child branches in left-to-right order after the "bs"
            qs <- forM (zip branches bs) (\(branch,bTag) ->  (go branch aAdvice bTag))
@@ -544,7 +544,7 @@ patternToQ compOpt (pOrig,(maxGroupIndex,_)) = (tnfa,aTags,aGroups) where
          --
          -- If the parent index is Nothing then this is part of a
          -- non-capturing subtree and ignored.  This is a lazy and
-         -- efficient alternative to rebuidling the tree with PGroup
+         -- efficient alternative to rebuilding the tree with PGroup
          -- Nothing replacing PGroup (Just _).
          --
          -- Guarded by the getParentIndex /= Nothing check is the
@@ -593,7 +593,7 @@ Change the NullView to use a tasktags instead of wintags since they are all PreU
          -- PNonEmpty means the child pattern p can be skipped by
          -- bypassing the pattern.  This is only used in the case p
          -- can accept 0 and can accept more than zero characters
-         -- (thus the assertions, enforcted by CorePattern.starTrans).
+         -- (thus the assertions, enforced by CorePattern.starTrans).
          -- The important thing about this case is intercept the
          -- "accept 0" possibility and replace with "skip".
          PNonEmpty p -> mdo

--- a/lib/Text/Regex/TDFA/NewDFA/Engine.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine.hs
@@ -178,7 +178,7 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
 -- position and the basePos position.  Entries in different groups
 -- will never be comparable in the future so they can be processed
 -- separately.  Groups could probably be even more finely
--- distinguished, as a futher optimization, but the justification will
+-- distinguished, as a further optimization, but the justification will
 -- be tricky.
 --
 -- Current Tag-0 values are at most offset and all newly spawned
@@ -193,7 +193,7 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
 -- is avoided.
 --
 -- An entry in a group can only collide with that group's
--- descendents. compressOrbit sends each group to the compressGroup
+-- descendants. compressOrbit sends each group to the compressGroup
 -- command.
 --
 -- compressGroup on a single record checks whether it's Seq can be
@@ -201,19 +201,19 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
 -- this this not particularly important).
 --
 -- compressGroup on many records sorts and groups the members and zips
--- the groups with their new ordinal value.  The comparision is based
+-- the groups with their new ordinal value.  The comparison is based
 -- on the old ordinal value, then the inOrbit value, and then the (Seq
 -- Position) data.
 --
 -- The old ordinals of the group will all be Nothing or all be Just,
 -- but this condition is neither checked nor violations detected.
--- This comparision is justified because once records get different
+-- This comparison is justified because once records get different
 -- ordinals assigned they will never change places.
 --
 -- The inOrbit Bool is only different if one of them has set the stop
--- position to at most (succ offset).  They will obly be compared if
+-- position to at most (succ offset).  They will only be compared if
 -- the other one leaves, an its stop position will be at least offset.
--- The previous sentence is justified by inspectin of the "assemble"
+-- The previous sentence is justified by inspection of the "assemble"
 -- function in the TDFA module: there is no (PostUpdate
 -- LeaveOrbitTask) so the largest possible value for the stop Tag is
 -- (pred offset). Thus the record with inOrbit==False would beat (be
@@ -221,7 +221,7 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
 --
 -- The Seq comparison is safe because the largest existing Position
 -- value is (pred offset) and the smallest future Position value is
--- offset.  The previous sentence is justified by inspectin of the
+-- offset.  The previous sentence is justified by inspection of the
 -- "assemble" function in the TDFA module: there is no (PostUpdate
 -- EnterOrbitTags) so the largest possible value in the Seq is (pred
 -- offset).
@@ -323,7 +323,7 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
 -- A non-empty winner from the startState might obscure a potential
 -- empty winner (form the startState at the current offset).  This
 -- winEmpty possibility is also checked for. (unit test pattern ".*")
--- (futher test "(.+|.+.)*" on "aa\n")
+-- (further test "(.+|.+.)*" on "aa\n")
 
         {-# INLINE processWinner #-}
         processWinner s1 did dt w offset = {-# SCC "goNext.newWinnerThenProceed" #-} do

--- a/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
@@ -115,14 +115,14 @@ execMatch (Regex { regex_dfa =  DFA {d_id=didIn,d_dt=dtIn}
 -- compressOrbit.
 --
 -- compressOrbit on such a Tag loops through all the NFS states'
--- m_orbit record, discardind ones that are Nothing and discarding
+-- m_orbit record, discarding ones that are Nothing and discarding
 -- ones that are too new to care about (after the cutoff value).
 --
 -- compressOrbit then groups the Orbits records by the Tag-0 start
--- position and the basePos position.  Entried in different groups
+-- position and the basePos position.  Entries in different groups
 -- will never be comparable in the future so they can be processed
 -- separately.  Groups could probably be even more finely
--- distinguished, as a futher optimization, but the justification will
+-- distinguished, as a further optimization, but the justification will
 -- be tricky.
 --
 -- Current Tag-0 values are at most offset and all newly spawned
@@ -137,7 +137,7 @@ execMatch (Regex { regex_dfa =  DFA {d_id=didIn,d_dt=dtIn}
 -- is avoided.
 --
 -- An entry in a group can only collide with that group's
--- descendents. compressOrbit sends each group to the compressGroup
+-- descendants. compressOrbit sends each group to the compressGroup
 -- command.
 --
 -- compressGroup on a single record checks whether it's Seq can be
@@ -145,19 +145,19 @@ execMatch (Regex { regex_dfa =  DFA {d_id=didIn,d_dt=dtIn}
 -- this this not particularly important).
 --
 -- compressGroup on many records sorts and groups the members and zips
--- the groups with their new ordinal value.  The comparision is based
+-- the groups with their new ordinal value.  The comparison is based
 -- on the old ordinal value, then the inOrbit value, and then the (Seq
 -- Position) data.
 --
 -- The old ordinals of the group will all be Nothing or all be Just,
 -- but this condition is neither checked nor violations detected.
--- This comparision is justified because once records get different
+-- This comparison is justified because once records get different
 -- ordinals assigned they will never change places.
 --
 -- The inOrbit Bool is only different if one of them has set the stop
 -- position to at most (succ offset).  They will obly be compared if
 -- the other one leaves, an its stop position will be at least offset.
--- The previous sentence is justified by inspectin of the "assemble"
+-- The previous sentence is justified by inspection of the "assemble"
 -- function in the TDFA module: there is no (PostUpdate
 -- LeaveOrbitTask) so the largest possible value for the stop Tag is
 -- (pred offset). Thus the record with inOrbit==False would beat (be
@@ -165,7 +165,7 @@ execMatch (Regex { regex_dfa =  DFA {d_id=didIn,d_dt=dtIn}
 --
 -- The Seq comparison is safe because the largest existing Position
 -- value is (pred offset) and the smallest future Position value is
--- offset.  The previous sentence is justified by inspectin of the
+-- offset.  The previous sentence is justified by inspection of the
 -- "assemble" function in the TDFA module: there is no (PostUpdate
 -- EnterOrbitTags) so the largest possible value in the Seq is (pred
 -- offset).
@@ -269,7 +269,7 @@ execMatch (Regex { regex_dfa =  DFA {d_id=didIn,d_dt=dtIn}
 -- A non-empty winner from the startState might obscure a potential
 -- empty winner (form the startState at the current offset).  This
 -- winEmpty possibility is also checked for. (unit test pattern ".*")
--- (futher test "(.+|.+.)*" on "aa\n")
+-- (further test "(.+|.+.)*" on "aa\n")
 
         {-# INLINE processWinner #-}
         processWinner :: MScratch s -> IntMap Instructions -> Position -> ST s ()

--- a/lib/Text/Regex/TDFA/Pattern.hs
+++ b/lib/Text/Regex/TDFA/Pattern.hs
@@ -139,7 +139,7 @@ instance Show PatternSetEquivalenceClass where
 starTrans :: Pattern -> Pattern
 starTrans = dfsPattern (simplify' . starTrans')
 
--- | Apply a Pattern transfomation function depth first
+-- | Apply a Pattern transformation function depth first
 dfsPattern :: (Pattern -> Pattern)  -- ^ The transformation function
            -> Pattern               -- ^ The Pattern to transform
            -> Pattern               -- ^ The transformed Pattern

--- a/lib/Text/Regex/TDFA/ReadRegex.hs
+++ b/lib/Text/Regex/TDFA/ReadRegex.hs
@@ -33,7 +33,7 @@ parseRegex x = runParser (do pat <- p_regex
 p_regex :: CharParser (GroupIndex,Int) Pattern
 p_regex = liftM POr $ sepBy1 p_branch (char '|')
 
--- man re_format helps alot, it says one-or-more pieces so this is
+-- man re_format helps a lot, it says one-or-more pieces so this is
 -- many1 not many.  Use "()" to indicate an empty piece.
 p_branch = liftM PConcat $ many1 p_piece
 

--- a/lib/Text/Regex/TDFA/String.hs
+++ b/lib/Text/Regex/TDFA/String.hs
@@ -66,7 +66,7 @@ regexec r s =
           rest = map fst (tail (elems mt)) -- will be []
       in Right (Just (pre,main,post,rest))
 
--- Minimal defintion for now
+-- Minimal definition for now
 instance RegexLike Regex String where
   matchOnce r s = listToMaybe (matchAll r s)
   matchAll r s = execMatch r 0 '\n' s

--- a/lib/Text/Regex/TDFA/TDFA.hs
+++ b/lib/Text/Regex/TDFA/TDFA.hs
@@ -1,5 +1,5 @@
 -- | "Text.Regex.TDFA.TDFA" converts the QNFA from TNFA into the DFA.
--- A DFA state corresponds to a Set of QNFA states, repesented as list
+-- A DFA state corresponds to a Set of QNFA states, represented as list
 -- of Index which are used to lookup the DFA state in a lazy Trie
 -- which holds all possible subsets of QNFA states.
 module Text.Regex.TDFA.TDFA(patternToRegex,DFA(..),DT(..)

--- a/lib/Text/Regex/TDFA/TNFA.hs
+++ b/lib/Text/Regex/TDFA/TNFA.hs
@@ -19,7 +19,7 @@
 --
 -- The QNFA for a Pattern with a starTraned Q\/P form with N one
 -- character accepting leaves has at most N+1 nodes.  These nodes
--- repesent the future choices after accepting a leaf.  The processing
+-- represent the future choices after accepting a leaf.  The processing
 -- of Or nodes often reduces this number by sharing at the end of the
 -- different paths.  Turning off capturing while compiling the pattern
 -- may (future extension) reduce this further for some patterns by
@@ -71,7 +71,7 @@ debug _ s = s
 
 qtwin,qtlose :: QT
 -- qtwin is the continuation after matching the whole pattern.  It has
--- no futher transitions and sets tag #1 to the current position.
+-- no further transitions and sets tag #1 to the current position.
 qtwin = Simple {qt_win=[(1,PreUpdate TagTask)],qt_trans=mempty,qt_other=mempty}
 -- qtlose is the continuation to nothing, used when ^ or $ tests fail.
 qtlose = Simple {qt_win=mempty,qt_trans=mempty,qt_other=mempty}
@@ -221,7 +221,7 @@ applyTest (wt,dopa) qt | nullQT qt = qt
 -- are handled.
 --
 -- mergeQT_2nd is used by the NonEmpty case and always discards the
--- first argument's win and uses the second argment's win.
+-- first argument's win and uses the second argument's win.
 --
 -- mergeAltQT is used by the Or cases and is biased to the first
 -- argument's winning transition, if present.
@@ -238,7 +238,7 @@ mergeQT q1 q2 | nullQT q1 = q2  -- union wins
               | nullQT q2 = q1  -- union wins
               | otherwise = mergeQTWith mappend q1 q2 -- no preference, win with combined SetTag XXX is the wrong thing! "(.?)*"
 
--- This takes a function which implements a policy on mergining
+-- This takes a function which implements a policy on merging
 -- winning transitions and then merges all the transitions.  It opens
 -- the CharMap newtype for more efficient operation, then rewraps it.
 mergeQTWith :: (WinTags -> WinTags -> WinTags) -> QT -> QT -> QT
@@ -355,7 +355,7 @@ getQNFA s (tags,Right qt) = newQNFA s (prependTags' (promoteTasks PreUpdate tags
 getQT :: E -> QT
 getQT (tags,cont) = prependTags' (promoteTasks PreUpdate tags) (either q_qt id cont)
 
--- 2009: This looks realllly dodgy, since it can convert a QNFA/Testing to a QT/Testing
+-- 2009: This looks really dodgy, since it can convert a QNFA/Testing to a QT/Testing
 -- without actually achieving anything except adding a DoPa to the Testing.  A diagnostic
 -- series of runs might be needed to decide if this ever creates orphan id numbers.
 -- Then applyTest might need to keep track of whether it actually changes anything.
@@ -408,7 +408,7 @@ getE (_,_,Just (tags,qnfa)) = (tags, Left qnfa)  -- consume optimized mQNFA valu
 getE (eLoop,Just accepting,_) = fromQT (mergeQT (getQT eLoop) (getQT accepting))
 getE (eLoop,Nothing,_) = eLoop
 
--- 2009: See coment for addTest.  Here is a case where the third component might be a (Just qnfa) and it
+-- 2009: See comment for addTest.  Here is a case where the third component might be a (Just qnfa) and it
 -- is being lost even though the added test might be redundant.
 addTestAC :: TestInfo -> ActCont -> ActCont
 addTestAC ti (e,mE,_) = (addTest ti e
@@ -756,7 +756,7 @@ qToNFA compOpt qTop = (q_id startingQNFA
            let trans = toMap mempty . S.toAscList . addNewline . decodePatternSet $ ps
            in Simple { qt_win = mempty, qt_trans = trans, qt_other = target }
          _ -> err ("Cannot acceptTrans pattern "++show (qTop,pIn))
-    where  -- Take a common destination and a sorted list of unique chraceters
+    where  -- Take a common destination and a sorted list of unique characters
            -- and create a map from those characters to the common destination
       toMap :: IntMap [(DoPa,[(Tag, TagUpdate)])] -> [Char]
             -> CharMap (IntMap [(DoPa,[(Tag, TagUpdate)])])
@@ -795,7 +795,7 @@ decodePatternSet (PatternSet msc mscc _ msec) =
       withMSEC = foldl (flip S.insert) withMSCC (maybe [] (concatMap unSEC . S.toAscList) msec)
   in withMSEC
 
--- | This returns the disctince ascending list of characters
+-- | This returns the distinct ascending list of characters
 -- represented by [: :] values in legalCharacterClasses; unrecognized
 -- class names return an empty string
 decodeCharacterClass :: PatternSetCharacterClass -> String


### PR DESCRIPTION
lib/Text/Regex/TDFA/Common.hs
lib/Text/Regex/TDFA/CorePattern.hs
lib/Text/Regex/TDFA/NewDFA/Engine.hs
lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
lib/Text/Regex/TDFA/Pattern.hs
lib/Text/Regex/TDFA/ReadRegex.hs
lib/Text/Regex/TDFA/String.hs
lib/Text/Regex/TDFA/TDFA.hs
lib/Text/Regex/TDFA/TNFA.hs

<hr>

@andreasabel have you an opinion on the following 

```
$ grep -nr orderinal regex-tdfa
regex-tdfa/lib/Text/Regex/TDFA/Common.hs:249:-- The orderinal code is being written XXX TODO document it.
$ grep -nr soure regex-tdfa
regex-tdfa/lib/Text/Regex/TDFA/TNFA.hs:14:-- transition for each (soure,destination) pair.  The transitions are
$ grep -nr souce regex-tdfa
regex-tdfa/lib/Text/Regex/TDFA/NewDFA/Engine.hs:719:copySTU _souce@(STUArray _ _ _ msource) _destination@(STUArray _ _ _ mdest) =
regex-tdfa/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs:616:copySTU _souce@(STUArray _ _ _ msource) _destination@(STUArray _ _ _ mdest) =
$
```