### PR TITLE
Fix #21 (deprecation warnings) by correct `MIN_VERSION_containers(0,5,11)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ For the package version policy (PVP), see  http://pvp.haskell.org/faq .
 
 _2022-07-14, Andreas Abel_
 
-- Fix an `undefined` in `Show PatternSet` [#37](https://github.com/haskell-hvr/regex-tdfa/issues/37))
+- Fix an `undefined` in `Show PatternSet` ([#37](https://github.com/haskell-hvr/regex-tdfa/issues/37))
 - Document POSIX character classes (e.g. `[[:digit:]]`)
 
 ### 1.3.1.2 Revision 1

--- a/lib/Data/IntMap/CharMap2.hs
+++ b/lib/Data/IntMap/CharMap2.hs
@@ -9,7 +9,7 @@ import Data.Char (chr)
 import Data.Char as C(ord)
 import Data.List as L (map)
 import qualified Data.IntMap as M
-#if MIN_VERSION_containers(0,6,0)
+#if MIN_VERSION_containers(0,5,11)
 import qualified Data.IntMap.Internal.Debug as MD
 #else
 import qualified Data.IntMap as MD

--- a/lib/Data/IntMap/EnumMap2.hs
+++ b/lib/Data/IntMap/EnumMap2.hs
@@ -4,7 +4,7 @@ module Data.IntMap.EnumMap2 where
 
 import Data.Foldable as F (Foldable(foldMap))
 import qualified Data.IntMap as M
-#if MIN_VERSION_containers(0,6,0)
+#if MIN_VERSION_containers(0,5,11)
 import qualified Data.IntMap.Internal.Debug as MD
 #else
 import qualified Data.IntMap as MD


### PR DESCRIPTION
Fix #21 (deprecation warnings) by correct `MIN_VERSION_containers(0,5,11)`.

Actually, correct would be `MIN_VERSION_containers(0,5,10,2)`, and the warning is still raised for `containers-0.5.10.2`.  However, there is no 4-ary version of this ternary macro.

Problem remains for GHC 8.2.2: https://github.com/haskell-hvr/regex-tdfa/runs/7355913740?check_suite_focus=true#step:18:27