### PR TITLE
Fix #1: parsing of dashes in bracket expressions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -146,7 +146,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -243,7 +243,7 @@ jobs:
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
           fi
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(regex-tdfa|text)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|regex-tdfa|text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -268,7 +268,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_regex_tdfa} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -146,7 +146,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90400)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -268,7 +268,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_regex_tdfa} || false

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -7,4 +7,6 @@ constraint-set mtl-2.3
   constraints: mtl >= 2.3, transformers >= 0.6
 
 -- doctest-parallel requires base >= 4.10
-tests: >= 8.2
+-- and does not support GHC 9.4 as of 2022-07-16
+-- <https://github.com/martijnbastiaan/doctest-parallel/issues/42>
+tests: >= 8.2 && < 9.4

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,10 @@
 branches: master
 
-installed: +all -text
+installed: +all -text -Cabal
 
 constraint-set mtl-2.3
   ghc: >= 8.6
   constraints: mtl >= 2.3, transformers >= 0.6
+
+-- doctest-parallel requires base >= 4.10
+tests: >= 8.2

--- a/lib/Text/Regex/TDFA.hs
+++ b/lib/Text/Regex/TDFA.hs
@@ -32,11 +32,17 @@ import "Text.Regex.TDFA"
 = Basics
 
 @
->>> let emailRegex = "[a-zA-Z0-9+.\\_-]+\\@[a-zA-Z-]+\\.[a-z]+"
->>> "my email is firstname-lastname_1974@e-mail.com" =~ emailRegex :: Bool
+>>> let emailRegex = "[a-zA-Z0-9+._-]+\\@[-a-zA-Z]+\\.[a-z]+"
+>>> "my email is first-name.lastname_1974@e-mail.com" =~ emailRegex :: Bool
 True
 
 >>> "invalid@mail@com" =~ emailRegex :: Bool
+False
+
+>>> "invalid@mail.COM" =~ emailRegex :: Bool
+False
+
+>>> "#@invalid.com" =~ emailRegex :: Bool
 False
 
 /-- non-monadic/
@@ -150,6 +156,12 @@ simply ignored and equivalence classes like [=a=] are converted to
 just [a].  The character classes like [:alnum:] are supported over
 ASCII only, valid classes are alnum, digit, punct, alpha, graph,
 space, blank, lower, upper, cntrl, print, xdigit, word.
+
+@
+>>> getAllTextMatches ("john anne yifan" =~ "[[:lower:]]+") :: [String]
+["john","anne","yifan"]
+
+@
 
 This package does not provide "basic" regular expressions.  This
 package does not provide back references inside regular expressions.

--- a/lib/Text/Regex/TDFA.hs
+++ b/lib/Text/Regex/TDFA.hs
@@ -32,9 +32,12 @@ import "Text.Regex.TDFA"
 = Basics
 
 @
-λ> let emailRegex = "[a-zA-Z0-9+.\_-]+\@[a-zA-Z-]+\\\\.[a-z]+"
-λ> "my email is email@email.com" '=~' emailRegex :: Bool
->>> True
+>>> let emailRegex = "[a-zA-Z0-9+.\\_-]+\\@[a-zA-Z-]+\\.[a-z]+"
+>>> "my email is firstname-lastname_1974@e-mail.com" =~ emailRegex :: Bool
+True
+
+>>> "invalid@mail@com" =~ emailRegex :: Bool
+False
 
 /-- non-monadic/
 λ> \<to-match-against\> '=~' \<regex\>
@@ -61,11 +64,12 @@ type you want, especially if you're trying things out at the REPL.
 /-- returns empty string if no match/
 a '=~' b :: String  /-- or ByteString, or Text.../
 
-λ> "alexis-de-tocqueville" '=~' "[a-z]+" :: String
->>> "alexis"
+>>> "alexis-de-tocqueville" =~ "[a-z]+" :: String
+"alexis"
 
-λ> "alexis-de-tocqueville" '=~' "[0-9]+" :: String
->>> ""
+>>> "alexis-de-tocqueville" =~ "[0-9]+" :: String
+""
+
 @
 
 == Check if it matched at all
@@ -73,8 +77,9 @@ a '=~' b :: String  /-- or ByteString, or Text.../
 @
 a '=~' b :: Bool
 
-λ> "alexis-de-tocqueville" '=~' "[a-z]+" :: Bool
->>> True
+>>> "alexis-de-tocqueville" =~ "[a-z]+" :: Bool
+True
+
 @
 
 == Get first match + text before/after
@@ -84,11 +89,12 @@ a '=~' b :: Bool
 /-- string in the first element of the tuple/
 a =~ b :: (String, String, String)
 
-λ> "alexis-de-tocqueville" '=~' "de" :: (String, String, String)
->>> ("alexis-", "de", "-tocqueville")
+>>> "alexis-de-tocqueville" =~ "de" :: (String, String, String)
+("alexis-","de","-tocqueville")
 
-λ> "alexis-de-tocqueville" '=~' "kant" :: (String, String, String)
->>> ("alexis-de-tocqueville", "", "")
+>>> "alexis-de-tocqueville" =~ "kant" :: (String, String, String)
+("alexis-de-tocqueville","","")
+
 @
 
 == Get first match + submatches
@@ -98,8 +104,9 @@ a =~ b :: (String, String, String)
 /-- submatch list is empty if regex doesn't match at all/
 a '=~' b :: (String, String, String, [String])
 
-λ> "div[attr=1234]" '=~' "div\\\\[([a-z]+)=([^]]+)\\\\]" :: (String, String, String, [String])
->>> ("", "div[attr=1234]", "", ["attr","1234"])
+>>> "div[attr=1234]" =~ "div\\[([a-z]+)=([^]]+)\\]" :: (String, String, String, [String])
+("","div[attr=1234]","",["attr","1234"])
+
 @
 
 == Get /all/ matches
@@ -108,8 +115,9 @@ a '=~' b :: (String, String, String, [String])
 /-- can also return Data.Array instead of List/
 'getAllTextMatches' (a '=~' b) :: [String]
 
-λ> 'getAllTextMatches' ("john anne yifan" '=~' "[a-z]+") :: [String]
->>> ["john","anne","yifan"]
+>>> getAllTextMatches ("john anne yifan" =~ "[a-z]+") :: [String]
+["john","anne","yifan"]
+
 @
 
 = Feature support
@@ -165,7 +173,7 @@ import Text.RawString.QQ
 import Text.Regex.TDFA
 
 λ> "2 * (3 + 1) / 4" '=~' [r|\\([^)]+\\)|] :: String
->>> "(3 + 1)"
+"(3 + 1)"
 @
 
 -}

--- a/lib/Text/Regex/TDFA/ReadRegex.hs
+++ b/lib/Text/Regex/TDFA/ReadRegex.hs
@@ -2,8 +2,8 @@
 -- Lazy\/Possessive\/Backrefs are not recognized.  Anchors \^ and \$ are
 -- recognized.
 --
--- The PGroup returned always have (Maybe GroupIndex) set to (Just _)
--- and never to Nothing.
+-- A 'PGroup' returned always has @(Maybe 'GroupIndex')@ set to @(Just _)@
+-- and never to @Nothing@.
 
 module Text.Regex.TDFA.ReadRegex (parseRegex) where
 
@@ -17,8 +17,13 @@ import Text.ParserCombinators.Parsec((<|>), (<?>),
 import Control.Monad(liftM, when, guard)
 import qualified Data.Set as Set(fromList)
 
--- | BracketElement is internal to this module
-data BracketElement = BEChar Char | BEChars String | BEColl String | BEEquiv String | BEClass String
+-- | An element inside @[...]@, denoting a character class.
+data BracketElement
+  = BEChar  Char    -- ^ A single character.
+  | BEChars String  -- ^ A sequence of characters expanded from a range (e.g. @a-z@).
+  | BEColl  String  -- ^ @foo@ in @[.foo.]@.
+  | BEEquiv String  -- ^ @bar@ in @[=bar=]@.
+  | BEClass String  -- ^ A POSIX character class (candidate), e.g. @alpha@ parsed from @[:alpha:]@.
 
 -- | Return either an error message or a tuple of the Pattern and the
 -- largest group index and the largest DoPa index (both have smallest

--- a/lib/Text/Regex/TDFA/ReadRegex.hs
+++ b/lib/Text/Regex/TDFA/ReadRegex.hs
@@ -11,11 +11,12 @@ module Text.Regex.TDFA.ReadRegex (parseRegex) where
 
 import Text.Regex.TDFA.Pattern {- all -}
 import Text.ParserCombinators.Parsec((<|>), (<?>),
-  unexpected, try, runParser, many, getState, setState, CharParser, ParseError,
+  try, runParser, many, getState, setState, CharParser, ParseError,
   sepBy1, option, notFollowedBy, many1, lookAhead, eof, between,
   string, noneOf, digit, char, anyChar)
 
-import Control.Monad(liftM, when, guard)
+import Control.Monad (liftM, guard)
+
 import Data.Foldable (asum)
 import qualified Data.Set as Set(fromList)
 
@@ -168,9 +169,6 @@ p_set_elem_range = try $ do
 p_set_elem_char :: P BracketElement
 p_set_elem_char = do
   c <- noneOf "]"
-  when (c == '-') $ do
-    atEnd <- (lookAhead (char ']') >> return True) <|> (return False)
-    when (not atEnd) (unexpected "A dash is in the wrong place in a bracket")
   return (BEChar c)
 
 -- | Fail when 'BracketElement' is invalid, e.g. empty range @1-0@.

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -173,3 +173,16 @@ test-suite regex-tdfa-unittest
 
   if flag(force-O2)
     ghc-options:        -O2
+
+test-suite doc-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        DocTestMain.hs
+
+  build-depends:
+      base
+    , regex-tdfa
+    , doctest-parallel >= 0.2.2
+        -- doctest-parallel-0.2.2 is the first to filter out autogen-modules
+
+  default-language:     Haskell2010

--- a/test/DocTestMain.hs
+++ b/test/DocTestMain.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import System.Environment
+         ( getArgs )
+import Test.DocTest
+         ( mainFromLibrary )
+import Test.DocTest.Helpers
+         ( extractSpecificCabalLibrary, findCabalPackage )
+
+main :: IO ()
+main = do
+  args <- getArgs
+  pkg  <- findCabalPackage "regex-tdfa"
+  -- Need to give the library name, otherwise the parser does not find it.
+  lib  <- extractSpecificCabalLibrary Nothing pkg
+  mainFromLibrary lib args


### PR DESCRIPTION
- Fix #1: parsing problems with dashes in bracket expressions
- add `doc-test` testsuite
- fix examples in docs
- limit tests in CI to GHC >= 8.2 (for `doctest-parallel`)