### PR TITLE
Fix #1 (again) with proper test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 For the package version policy (PVP), see  http://pvp.haskell.org/faq .
 
+### 1.3.1.5
+
+_2022-07-18, Andreas Abel_
+
+- Allow dash (`-`) as start of a range, e.g. `[--z]`
+  ([#1](https://github.com/haskell-hvr/regex-tdfa/issues/1),
+  [#45](https://github.com/haskell-hvr/regex-tdfa/pull/45))
+- Tested with GHC 7.4 - 9.4
+
 ### 1.3.1.4
 
 _2022-07-17, Andreas Abel_

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+
+write-ghc-environment-files: always

--- a/lib/Text/Regex/TDFA.hs
+++ b/lib/Text/Regex/TDFA.hs
@@ -124,6 +124,9 @@ a '=~' b :: (String, String, String, [String])
 >>> getAllTextMatches ("john anne yifan" =~ "[a-z]+") :: [String]
 ["john","anne","yifan"]
 
+>>> getAllTextMatches ("* - . a + z" =~ "[--z]+") :: [String]
+["-",".","a","z"]
+
 @
 
 = Feature support

--- a/lib/Text/Regex/TDFA/ReadRegex.hs
+++ b/lib/Text/Regex/TDFA/ReadRegex.hs
@@ -120,7 +120,7 @@ p_bracket :: P Pattern
 p_bracket = (char '[') >> ( (char '^' >> p_set True) <|> (p_set False) )
 
 p_set :: Bool -> P Pattern
-p_set invert = do initial <- (option "" ((char ']' >> return "]") <|> (char '-' >> return "-")))
+p_set invert = do initial <- option "" (char ']' >> return "]")
                   values <- if null initial then many1 p_set_elem else many p_set_elem
                   _ <- char ']'
                   ci <- char_index
@@ -161,7 +161,7 @@ p_set_elem_coll =  liftM BEColl $
 
 p_set_elem_range :: P BracketElement
 p_set_elem_range = try $ do
-  start <- noneOf "]-"
+  start <- noneOf "]"
   _  <- char '-'
   end <- noneOf "]"
   return $ BERange start end

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -1,6 +1,6 @@
 cabal-version:          1.12
 name:                   regex-tdfa
-version:                1.3.1.4
+version:                1.3.1.5
 
 build-Type:             Simple
 license:                BSD3
@@ -46,7 +46,7 @@ source-repository head
 source-repository this
   type:                git
   location:            https://github.com/haskell-hvr/regex-tdfa.git
-  tag:                 v1.3.1.4
+  tag:                 v1.3.1.5
 
 flag force-O2
   default: False


### PR DESCRIPTION
Fix #1 (again) with proper test.

Ranges beginning with `-` were not recognized.

Candidate at: https://hackage.haskell.org/package/regex-tdfa-1.3.1.5/candidate