### PR TITLE
Fix return type in `memcpy` FFI signature

### DIFF
--- a/lib/Text/Regex/TDFA/NewDFA/Engine.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine.hs
@@ -43,6 +43,7 @@ import Data.Sequence(Seq,ViewL(..),viewl)
 import qualified Data.Sequence as Seq(null)
 import qualified Data.ByteString.Char8 as SBS(ByteString)
 import qualified Data.ByteString.Lazy.Char8 as LBS(ByteString)
+import Foreign.Ptr(Ptr)
 
 import Text.Regex.Base(MatchArray,MatchOffset,MatchLength)
 import qualified Text.Regex.TDFA.IntArrTrieSet as Trie(lookupAsc)
@@ -705,7 +706,7 @@ updateCopy ((_i1,instructions),oldPos,newOrbit) preTag s2 i2 = do
 
 -- #ifdef __GLASGOW_HASKELL__
 foreign import ccall unsafe "memcpy"
-    memcpy :: MutableByteArray# RealWorld -> MutableByteArray# RealWorld -> Int# -> IO ()
+    memcpy :: MutableByteArray# RealWorld -> MutableByteArray# RealWorld -> Int# -> IO (Ptr a)
 
 {-
 Prelude Data.Array.Base> :i STUArray
@@ -722,7 +723,7 @@ copySTU _source@(STUArray _ _ _ msource) _destination@(STUArray _ _ _ mdest) =
 --  when (b1/=b2) (error ("\n\nWTF copySTU: "++show (b1,b2)))
   ST $ \s1# ->
     case sizeofMutableByteArray# msource        of { n# ->
-    case unsafeCoerce# memcpy mdest msource n# s1# of { (# s2#, () #) ->
+    case unsafeCoerce# memcpy mdest msource n# s1# of { (# s2#, _ #) ->
     (# s2#, () #) }}
 {-
 -- #else /* !__GLASGOW_HASKELL__ */

--- a/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
@@ -39,6 +39,7 @@ import Data.Sequence(Seq,ViewL(..),viewl)
 import qualified Data.Sequence as Seq(null)
 import qualified Data.ByteString.Char8 as SBS(ByteString)
 import qualified Data.ByteString.Lazy.Char8 as LBS(ByteString)
+import Foreign.Ptr(Ptr)
 
 import Text.Regex.Base(MatchArray,MatchOffset,MatchLength)
 import Text.Regex.TDFA.Common hiding (indent)
@@ -602,7 +603,7 @@ updateCopy ((_i1,instructions),oldPos,newOrbit) preTag s2 i2 = do
 
 -- #ifdef __GLASGOW_HASKELL__
 foreign import ccall unsafe "memcpy"
-    memcpy :: MutableByteArray# RealWorld -> MutableByteArray# RealWorld -> Int# -> IO ()
+    memcpy :: MutableByteArray# RealWorld -> MutableByteArray# RealWorld -> Int# -> IO (Ptr a)
 
 {-
 Prelude Data.Array.Base> :i STUArray
@@ -619,7 +620,7 @@ copySTU _source@(STUArray _ _ _ msource) _destination@(STUArray _ _ _ mdest) =
 --  when (b1/=b2) (error ("\n\nWTF copySTU: "++show (b1,b2)))
   ST $ \s1# ->
     case sizeofMutableByteArray# msource        of { n# ->
-    case unsafeCoerce# memcpy mdest msource n# s1# of { (# s2#, () #) ->
+    case unsafeCoerce# memcpy mdest msource n# s1# of { (# s2#, _ #) ->
     (# s2#, () #) }}
 {-
 -- #else /* !__GLASGOW_HASKELL__ */


### PR DESCRIPTION
Consider the signature of `memcpy` (e.g. from [here](https://man7.org/linux/man-pages/man3/memcpy.3.html)):

```c
void *memcpy(void *restrict dest, const void *restrict src, size_t n);
```

Note that the return type is `void *`, a pointer, and not `void`. Hence, this PR changes the return type from `IO ()` to `IO (Ptr a)`; was e.g. done [here](https://github.com/haskell/array/commit/d3dfd7bf750a0c0479ead175c8120c7dcb9d47fe#diff-f25f65858bd6a3eedeb9012d90e4cad6187a2b203017f2e5ff9aed34297437a8R1597) in the very similar code in `array`.

This will probably not change anything on most platform; concrete motivation is that compiling `regex-tdfa` using the GHC 9.6 WASM backend did yield a link-time warning:
```
wasm-ld: warning: function signature mismatch: memcpy
>>> defined as (i32, i32, i32) -> void in [...]/lib/libHSregex-tdfa-1.3.2.1-[...].a(Engine.o)
>>> defined as (i32, i32, i32) -> i32 in [...]/share/wasi-sysroot/lib/wasm32-wasi/libc.a(memcpy.o)
```