### PR TITLE
bytestring 0.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.1
+# version: 0.16.4
 #
-# REGENDATA ("0.16.1",["github","regex-tdfa.cabal"])
+# REGENDATA ("0.16.4",["github","regex-tdfa.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.5
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -1,6 +1,7 @@
 cabal-version:          1.12
 name:                   regex-tdfa
 version:                1.3.2.1
+x-revision:             1
 
 build-Type:             Simple
 license:                BSD3
@@ -100,7 +101,7 @@ library
                       , semigroups         == 0.18.* || == 0.19.*
   build-depends:        array              >= 0.4    && < 0.6
                       , base               >= 4.5    && < 5
-                      , bytestring         >= 0.9.2  && < 0.12
+                      , bytestring         >= 0.9.2  && < 0.13
                       , containers         >= 0.4.2  && < 0.7
                       , mtl                >= 2.1.3  && < 2.4
                       , parsec             == 3.1.*

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -25,9 +25,9 @@ extra-source-files:
   test/cases/*.txt
 
 tested-with:
-  GHC == 9.6.1
+  GHC == 9.6.2
   GHC == 9.4.5
-  GHC == 9.2.7
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4


### PR DESCRIPTION
- Bump Haskell CI to latest GHCs: 9.6.2 9.2.8
- v1.3.2.1-r1: allow bytestring-0.12
