### PR TITLE
v1.3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 For the package version policy (PVP), see  http://pvp.haskell.org/faq .
 
+### 1.3.2.2
+
+_2023-08-02, Andreas Abel_
+
+- Fix return type in `memcpy` FFI signature ([#52](https://github.com/haskell-hvr/regex-tdfa/pull/52))
+- Refactor `regexec` to avoid partial functions `tail` and `(!0)`
+- Tested with GHC 7.4 - 9.8.1-alpha1
+
 ### 1.3.2.1
 
 _2023-05-19, Andreas Abel_

--- a/lib/Text/Regex/TDFA/ByteString.hs
+++ b/lib/Text/Regex/TDFA/ByteString.hs
@@ -63,18 +63,16 @@ compile compOpt execOpt bs =
     Left err -> Left ("parseRegex for Text.Regex.TDFA.ByteString failed:"++show err)
     Right pattern -> Right (patternToRegex pattern compOpt execOpt)
 
-execute :: Regex      -- ^ Compiled regular expression
+execute :: Regex        -- ^ Compiled regular expression
         -> B.ByteString -- ^ ByteString to match against
         -> Either String (Maybe MatchArray)
 execute r bs = Right (matchOnce r bs)
 
-regexec :: Regex      -- ^ Compiled regular expression
+regexec :: Regex        -- ^ Compiled regular expression
         -> B.ByteString -- ^ ByteString to match against
         -> Either String (Maybe (B.ByteString, B.ByteString, B.ByteString, [B.ByteString]))
-regexec r bs =
-  case matchOnceText r bs of
-    Nothing -> Right (Nothing)
-    Just (pre,mt,post) ->
-      let main = fst (mt!0)
-          rest = map fst (tail (elems mt)) -- will be []
-      in Right (Just (pre,main,post,rest))
+regexec r txt = Right $
+  case matchOnceText r txt of
+    Just (pre, mt, post) | main:rest <- map fst (elems mt)
+      -> Just (pre, main, post, rest)
+    _ -> Nothing

--- a/lib/Text/Regex/TDFA/ByteString/Lazy.hs
+++ b/lib/Text/Regex/TDFA/ByteString/Lazy.hs
@@ -79,18 +79,16 @@ compile compOpt execOpt bs =
     Left err -> Left ("parseRegex for Text.Regex.TDFA.ByteString failed:"++show err)
     Right pattern -> Right (patternToRegex pattern compOpt execOpt)
 
-execute :: Regex      -- ^ Compiled regular expression
+execute :: Regex        -- ^ Compiled regular expression
         -> L.ByteString -- ^ ByteString to match against
         -> Either String (Maybe MatchArray)
 execute r bs = Right (matchOnce r bs)
 
-regexec :: Regex      -- ^ Compiled regular expression
+regexec :: Regex        -- ^ Compiled regular expression
         -> L.ByteString -- ^ ByteString to match against
         -> Either String (Maybe (L.ByteString, L.ByteString, L.ByteString, [L.ByteString]))
-regexec r bs =
-  case matchOnceText r bs of
-    Nothing -> Right (Nothing)
-    Just (pre,mt,post) ->
-      let main = fst (mt!0)
-          rest = map fst (tail (elems mt)) -- will be []
-      in Right (Just (pre,main,post,rest))
+regexec r txt = Right $
+  case matchOnceText r txt of
+    Just (pre, mt, post) | main:rest <- map fst (elems mt)
+      -> Just (pre, main, post, rest)
+    _ -> Nothing

--- a/lib/Text/Regex/TDFA/Sequence.hs
+++ b/lib/Text/Regex/TDFA/Sequence.hs
@@ -61,25 +61,23 @@ instance RegexLike Regex (Seq Char) where
 
 compile :: CompOption -- ^ Flags (summed together)
         -> ExecOption -- ^ Flags (summed together)
-        -> (Seq Char) -- ^ The regular expression to compile
+        -> Seq Char   -- ^ The regular expression to compile
         -> Either String Regex -- ^ Returns: the compiled regular expression
 compile compOpt execOpt bs =
   case parseRegex (F.toList bs) of
     Left err -> Left ("parseRegex for Text.Regex.TDFA.Sequence failed:"++show err)
     Right pattern -> Right (patternToRegex pattern compOpt execOpt)
 
-execute :: Regex      -- ^ Compiled regular expression
-        -> (Seq Char) -- ^ ByteString to match against
+execute :: Regex    -- ^ Compiled regular expression
+        -> Seq Char -- ^ String to match against
         -> Either String (Maybe MatchArray)
 execute r bs = Right (matchOnce r bs)
 
-regexec :: Regex      -- ^ Compiled regular expression
-        -> (Seq Char) -- ^ ByteString to match against
-        -> Either String (Maybe ((Seq Char), (Seq Char), (Seq Char), [(Seq Char)]))
-regexec r bs =
-  case matchOnceText r bs of
-    Nothing -> Right (Nothing)
-    Just (pre,mt,post) ->
-      let main = fst (mt!0)
-          rest = map fst (tail (elems mt)) -- will be []
-      in Right (Just (pre,main,post,rest))
+regexec :: Regex    -- ^ Compiled regular expression
+        -> Seq Char -- ^ String to match against
+        -> Either String (Maybe (Seq Char, Seq Char, Seq Char, [Seq Char]))
+regexec r txt = Right $
+  case matchOnceText r txt of
+    Just (pre, mt, post) | main:rest <- map fst (elems mt)
+      -> Just (pre, main, post, rest)
+    _ -> Nothing

--- a/lib/Text/Regex/TDFA/String.hs
+++ b/lib/Text/Regex/TDFA/String.hs
@@ -58,13 +58,11 @@ execute r s = Right (matchOnce r s)
 regexec :: Regex      -- ^ Compiled regular expression
         -> String     -- ^ String to match against
         -> Either String (Maybe (String, String, String, [String]))
-regexec r s =
-  case matchOnceText r s of
-    Nothing -> Right Nothing
-    Just (pre,mt,post) ->
-      let main = fst (mt!0)
-          rest = map fst (tail (elems mt)) -- will be []
-      in Right (Just (pre,main,post,rest))
+regexec r txt = Right $
+  case matchOnceText r txt of
+    Just (pre, mt, post) | main:rest <- map fst (elems mt)
+      -> Just (pre, main, post, rest)
+    _ -> Nothing
 
 -- Minimal definition for now
 instance RegexLike Regex String where

--- a/lib/Text/Regex/TDFA/Text.hs
+++ b/lib/Text/Regex/TDFA/Text.hs
@@ -83,19 +83,17 @@ compile compOpt execOpt txt =
     Right pattern -> Right (patternToRegex pattern compOpt execOpt)
 
 -- | @since 1.3.1
-execute :: Regex      -- ^ Compiled regular expression
+execute :: Regex  -- ^ Compiled regular expression
         -> T.Text -- ^ Text to match against
         -> Either String (Maybe MatchArray)
 execute r txt = Right (matchOnce r txt)
 
 -- | @since 1.3.1
-regexec :: Regex      -- ^ Compiled regular expression
+regexec :: Regex  -- ^ Compiled regular expression
         -> T.Text -- ^ Text to match against
         -> Either String (Maybe (T.Text, T.Text, T.Text, [T.Text]))
-regexec r txt =
+regexec r txt = Right $
   case matchOnceText r txt of
-    Nothing -> Right (Nothing)
-    Just (pre,mt,post) ->
-      let main = fst (mt!0)
-          rest = map fst (tail (elems mt)) -- will be []
-      in Right (Just (pre,main,post,rest))
+    Just (pre, mt, post) | main:rest <- map fst (elems mt)
+      -> Just (pre, main, post, rest)
+    _ -> Nothing

--- a/lib/Text/Regex/TDFA/Text/Lazy.hs
+++ b/lib/Text/Regex/TDFA/Text/Lazy.hs
@@ -91,19 +91,17 @@ compile compOpt execOpt txt =
     Right pattern -> Right (patternToRegex pattern compOpt execOpt)
 
 -- | @since 1.3.1
-execute :: Regex      -- ^ Compiled regular expression
+execute :: Regex  -- ^ Compiled regular expression
         -> L.Text -- ^ Text to match against
         -> Either String (Maybe MatchArray)
 execute r txt = Right (matchOnce r txt)
 
 -- | @since 1.3.1
-regexec :: Regex      -- ^ Compiled regular expression
+regexec :: Regex  -- ^ Compiled regular expression
         -> L.Text -- ^ Text to match against
         -> Either String (Maybe (L.Text, L.Text, L.Text, [L.Text]))
-regexec r txt =
+regexec r txt = Right $
   case matchOnceText r txt of
-    Nothing -> Right (Nothing)
-    Just (pre,mt,post) ->
-      let main = fst (mt!0)
-          rest = map fst (tail (elems mt)) -- will be []
-      in Right (Just (pre,main,post,rest))
+    Just (pre, mt, post) | main:rest <- map fst (elems mt)
+      -> Just (pre, main, post, rest)
+    _ -> Nothing

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -1,7 +1,6 @@
 cabal-version:          1.12
 name:                   regex-tdfa
-version:                1.3.2.1
-x-revision:             1
+version:                1.3.2.2
 
 build-Type:             Simple
 license:                BSD3
@@ -48,7 +47,7 @@ source-repository head
 source-repository this
   type:                git
   location:            https://github.com/haskell-hvr/regex-tdfa.git
-  tag:                 v1.3.2.1
+  tag:                 v1.3.2.2
 
 flag force-O2
   default: False

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -58,6 +58,12 @@ flag force-O2
     .
     __NOTE__: This flag is mostly provided for legacy use-cases. Nowadays you can conveniently control optimization levels on a per-package granularity via @cabal.project@ files; see <https://cabal.readthedocs.io/en/latest/nix-local-build.html#configuring-builds-with-cabal-project cabal's user-guide> for more details.
 
+flag doctest
+  default: True
+  manual: False
+  description:
+    Include test-suite doctest.
+
 library
   hs-source-dirs:       lib
 
@@ -176,7 +182,7 @@ test-suite regex-tdfa-unittest
   if flag(force-O2)
     ghc-options:        -O2
 
-test-suite doc-test
+test-suite doctest
   type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        DocTestMain.hs
@@ -188,3 +194,6 @@ test-suite doc-test
         -- doctest-parallel-0.2.2 is the first to filter out autogen-modules
 
   default-language:     Haskell2010
+
+  if !flag(doctest)
+    buildable: False


### PR DESCRIPTION
- Refactor regexec (6 times) to not use partial functions tail and !0
- New cabal flag `doctest` to control building the doctest test-suite
- v1.3.2.2 Bump and CHANGELOG

https://hackage.haskell.org/package/regex-tdfa-1.3.2.2/candidate