### PR TITLE
Fix typos in the repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ _2014-02-02, Chris Kuklewicz_
 
 ## 1.1.8
 
-Make ghc-7.0.2 on platorm 2011.2.0.0.0 happy
+Make ghc-7.0.2 on platform 2011.2.0.0.0 happy
 
 ## 1.1.7
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This modile is under this "3 clause" BSD license:
+This module is under this "3 clause" BSD license:
 
 Copyright (c) 2007-2009, Christopher Kuklewicz
 All rights reserved.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ By building on this thesis and adding a few more optimizations, regex-tdfa match
 
 Regardless of performance, nearly every single OS and Libra for POSIX regular expressions has bugs in sub-matches.  This was detailed on the [Regex POSIX Haskell wiki page](https://wiki.haskell.org/Regex_Posix), and can be demonstrated with the [regex-posix-unittest](http://hackage.haskell.org/package/regex-posix-unittest) suite of checks.  Test [regex-tdfa-unittest](http://hackage.haskell.org/package/regex-tdfa-unittest) should show regex-tdfa passing these same checks.  I owe my understanding of the correct behvior and many of these unit tests to Glenn Fowler at AT&T ("An Interpretation of the POSIX regex Standard").
 
-### Maintainance history
+### Maintenance history
 
 The original Darcs repository was at [code.haskell.org](http://code.haskell.org/regex-tdfa/).
 For a while a fork was maintained by Roman Cheplyaka as

--- a/lib/Text/Regex/TDFA/Common.hs
+++ b/lib/Text/Regex/TDFA/Common.hs
@@ -28,7 +28,7 @@ look key imap = IMap.findWithDefault (common_error "Text.Regex.DFA.Common" ("key
 
 common_error :: String -> String -> a
 common_error moduleName message =
-  error ("Explict error in module "++moduleName++" : "++message)
+  error ("Explicit error in module "++moduleName++" : "++message)
 
 on :: (t1 -> t1 -> t2) -> (t -> t1) -> t -> t -> t2
 f `on` g = (\x y -> (g x) `f` (g y))
@@ -109,7 +109,7 @@ data ExecOption = ExecOption {
     captureGroups :: Bool    -- ^ True by default.  Set to False to improve speed (and space).
   } deriving (Read,Show)
 
--- | Used by implementation to name certain 'Postion's during
+-- | Used by implementation to name certain 'Position's during
 -- matching. Identity of 'Position' tag to set during a transition.
 type Tag = Int
 

--- a/lib/Text/Regex/TDFA/TDFA.hs
+++ b/lib/Text/Regex/TDFA/TDFA.hs
@@ -264,14 +264,14 @@ bestTrans aTagOP (f:fs) | null fs = canonical f
                     -- this needs a leading Minimize tag inside at least the parent * operator
       Ignore -> GT -- XXX this is a guess in analogy with Maximize for the end bit of a group
       Orbit -> LT -- trace ("choose LT! Just "++show tag++" < Nothing") LT -- 2009 XXX : comment out next line and use the Orbit instead
---      Orbit -> err $ "bestTrans.choose : Very Unexpeted Orbit in Just Nothing: "++show (tag,post,aTagOP,f:fs)
+--      Orbit -> err $ "bestTrans.choose : Very Unexpected Orbit in Just Nothing: "++show (tag,post,aTagOP,f:fs)
   choose (Just (tag,post1)) (Just (_,post2)) =
     case aTagOP!tag of
       Maximize -> order
       Minimize -> flipOrder order
       Ignore -> EQ
       Orbit -> EQ
---      Orbit -> err $ "bestTrans.choose : Very Unexpeted Orbit in Just Just: "++show (tag,(post1,post2),aTagOP,f:fs)
+--      Orbit -> err $ "bestTrans.choose : Very Unexpected Orbit in Just Just: "++show (tag,(post1,post2),aTagOP,f:fs)
    where order = case (post1,post2) of
                    (SetPre,SetPre) -> EQ
                    (SetPost,SetPost) -> EQ

--- a/lib/Text/Regex/TDFA/TNFA.hs
+++ b/lib/Text/Regex/TDFA/TNFA.hs
@@ -7,7 +7,7 @@
 -- (That will require re-organizing the continuation data a bit)
 
 -- | "Text.Regex.TDFA.TNFA" converts the CorePattern Q\/P data (and its
--- Pattern leafs) to a QNFA tagged non-deterministic finite automata.
+-- Pattern leaves) to a QNFA tagged non-deterministic finite automata.
 --
 -- This holds every possible way to follow one state by another, while
 -- in the DFA these will be reduced by picking a single best

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -178,7 +178,7 @@ main = do
       putStrLn $ "Explanation and discussion of these tests on the wiki at http://www.haskell.org/haskellwiki/Regex_Posix including comparing results from different operating systems"
       putStrLn $ "Questions about this package to the author at email <TextRegexLazy@personal.mightyreason.com>"
       putStrLn $ "The type of both the pattern and test is " ++ show (typeOf (undefined :: RType))
-      putStrLn $ "Without extactly two arguments:"
+      putStrLn $ "Without exactly two arguments:"
       putStrLn $ "    This program runs all test files listed in test/data-dir/test-manifest.txt"
       putStrLn $ "    Lines with negative number are expected to fail, others are expected to pass."
       putStrLn $ "With exactly two arguments:"


### PR DESCRIPTION
used https://github.com/crate-ci/typos

I noticed this when one of my regex's triggered a call to `common_error` and just went ahead and ran `typos` on the whole repo.