### PR TITLE
Release v1.3.2.5

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250917
 #
-# REGENDATA ("0.19.20250506",["github","regex-tdfa.cabal"])
+# REGENDATA ("0.19.20250917",["github","regex-tdfa.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -37,9 +40,9 @@ jobs:
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.2
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.2
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -110,8 +113,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -187,7 +190,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -212,7 +215,9 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_regex_tdfa}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package regex-tdfa" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package regex-tdfa" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(regex-tdfa)$/; }' >> cabal.project.local

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /cabal.project.local
 /cabal.project.freeze
 /.ghc.environment.*
+/.stack-work/
+/stack*.yaml.lock
 
 TAGS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-### Unreleased
+### 1.3.2.5
 
-- Bump `cabal-version` to 2.0 to support field `autogen-modules`.
+_2025-09-29 Andreas Abel_
+
+- Bump `cabal-version` to 2.0 to support field `autogen-modules` ([#70](https://github.com/haskell-hvr/regex-tdfa/pull/70))
+- SPECIALIZE pragmas for faster `Text` matching ([#72](https://github.com/haskell-hvr/regex-tdfa/pull/72))
+- Address deprecation warning for `sizeofMutualByteArray#` ([#71](https://github.com/haskell-hvr/regex-tdfa/issues/71))
+- Tested with GHC 8.0 - 9.12.2
 
 ### 1.3.2.4
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,6 +2,8 @@ branches: master
 
 installed: +all
 
+error-incomplete-patterns: False
+
 -- constraint-set bytestring-0.12
 --   -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
 --   ghc: >= 8.0

--- a/lib/Text/Regex/TDFA/NewDFA/Engine.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine.hs
@@ -36,7 +36,8 @@ import Data.Maybe(catMaybes)
 import Data.Monoid as Mon(Monoid(..))
 import qualified Data.IntSet as ISet(toAscList)
 import Data.Array.IArray((!))
-import Data.List(partition,sort,foldl',sortBy,groupBy)
+import Data.List(partition,sort,sortBy,groupBy)
+import qualified Data.List as List
 import Data.STRef(STRef,newSTRef,readSTRef,writeSTRef)
 import qualified Control.Monad.ST.Lazy as L(ST,runST,strictToLazyST)
 import qualified Control.Monad.ST.Strict as S(ST)
@@ -313,7 +314,7 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
           earlyWin <- readSTRef (mq_earliest winQ)
           if earlyWin < earlyStart
             then do
-              winners <- fmap (foldl' (\ rest ws -> ws : rest) []) $
+              winners <- fmap (List.foldl' (\ rest ws -> ws : rest) []) $
                            getMQ earlyStart winQ
               writeSTRef storeNext (next s2 s1 did' dt' (succ offset) prev' input')
               mapM (tagsToGroupsST aGroups) winners
@@ -397,7 +398,7 @@ execMatch r@(Regex { regex_dfa = DFA {d_id=didIn,d_dt=dtIn}
           putMQ (WScratch newerPos) winQ
 
         finalizeWinners = do
-          winners <- fmap (foldl' (\ rest mqa -> mqa_ws mqa : rest) []) $
+          winners <- fmap (List.foldl' (\ rest mqa -> mqa_ws mqa : rest) []) $
                        readSTRef (mq_list winQ) -- reverses the winner list
           resetMQ winQ
           writeSTRef storeNext (return [])

--- a/lib/Text/Regex/TDFA/NewDFA/Engine.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine.hs
@@ -16,7 +16,7 @@ import Data.Array.Base(unsafeRead,unsafeWrite,STUArray(..))
 -- #ifdef __GLASGOW_HASKELL__
 import GHC.Arr(STArray(..))
 import GHC.ST(ST(..))
-import GHC.Exts(MutableByteArray#,RealWorld,Int#,sizeofMutableByteArray#,State#)
+import GHC.Exts(MutableByteArray#,RealWorld,Int#,getSizeofMutableByteArray#,State#)
 import Unsafe.Coerce (unsafeCoerce)
 {-
 -- #else
@@ -730,8 +730,8 @@ copySTU _source@(STUArray _ _ _ msource) _destination@(STUArray _ _ _ mdest) =
 --  b2 <- getBounds s2
 --  when (b1/=b2) (error ("\n\nWTF copySTU: "++show (b1,b2)))
   ST $ \s1# ->
-    case sizeofMutableByteArray# msource        of { n# ->
-    case memcpyST mdest msource n# s1# of { (# s2#, _ #) ->
+    case getSizeofMutableByteArray# msource s1# of { (# s1'#, n# #) ->
+    case memcpyST mdest msource n# s1'# of { (# s2#, _ #) ->
     (# s2#, () #) }}
 {-
 -- #else /* !__GLASGOW_HASKELL__ */

--- a/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
+++ b/lib/Text/Regex/TDFA/NewDFA/Engine_FA.hs
@@ -17,7 +17,7 @@ import Data.Array.Base(unsafeRead,unsafeWrite,STUArray(..))
 
 import GHC.Arr(STArray(..))
 import GHC.ST(ST(..))
-import GHC.Exts(MutableByteArray#,RealWorld,Int#,sizeofMutableByteArray#,unsafeCoerce#,State#)
+import GHC.Exts(MutableByteArray#,RealWorld,Int#,getSizeofMutableByteArray#,unsafeCoerce#,State#)
 
 import Prelude hiding ((!!))
 import Control.Monad(when,unless,forM,forM_,liftM2,foldM)
@@ -622,8 +622,8 @@ copySTU _source@(STUArray _ _ _ msource) _destination@(STUArray _ _ _ mdest) =
 --  b2 <- getBounds s2
 --  when (b1/=b2) (error ("\n\nWTF copySTU: "++show (b1,b2)))
   ST $ \s1# ->
-    case sizeofMutableByteArray# msource        of { n# ->
-    case memcpyST mdest msource n# s1# of { (# s2#, _ #) ->
+    case getSizeofMutableByteArray# msource s1# of { (# s1'#, n# #) ->
+    case memcpyST mdest msource n# s1'# of { (# s2#, _ #) ->
     (# s2#, () #) }}
 {-
 -- #else /* !__GLASGOW_HASKELL__ */

--- a/lib/Text/Regex/TDFA/TDFA.hs
+++ b/lib/Text/Regex/TDFA/TDFA.hs
@@ -18,7 +18,7 @@ import Data.IntMap.CharMap2(CharMap(..))
 import qualified Data.IntMap.CharMap2 as Map(empty)
 --import Data.IntSet(IntSet)
 import qualified Data.IntSet as ISet(empty,singleton,null)
-import Data.List(foldl')
+import qualified Data.List as List
 import qualified Data.Map (Map,empty,member,insert,elems)
 import Data.Sequence as S((|>),{-viewl,ViewL(..)-})
 
@@ -165,7 +165,7 @@ dfaMap = seen (Data.Map.empty) where
     if i `Data.Map.member` old
       then old
       else let new = Data.Map.insert i d old
-           in foldl' seen new (flattenDT dt)
+           in List.foldl' seen new (flattenDT dt)
 
 -- Get all trans_many states
 flattenDT :: DT -> [DFA]
@@ -223,7 +223,7 @@ bestTrans _ [] = err "bestTrans : There were no transition choose from!"
 bestTrans aTagOP (f:fs) | null fs = canonical f
                         | otherwise = answer -- if null toDisplay then answer else trace toDisplay answer
  where
-  answer = foldl' pick (canonical f) fs
+  answer = List.foldl' pick (canonical f) fs
   {- toDisplay | null fs = ""
                | otherwise = unlines $ "bestTrans" : show (answer) : "from among" : concatMap (\x -> [show x, show (toInstructions (snd x))]) (f:fs) -}
   canonical :: TagCommand -> (DoPa,Instructions)

--- a/lib/Text/Regex/TDFA/TNFA.hs
+++ b/lib/Text/Regex/TDFA/TNFA.hs
@@ -40,7 +40,7 @@ import Control.Monad(when)
 import Control.Monad.State(State,runState,execState,get,put,modify)
 import Data.Array.IArray(Array,array)
 import Data.Char(toLower,toUpper,isAlpha,ord)
-import Data.List(foldl')
+import qualified Data.List as List
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IMap(toAscList,null,unionWith,singleton,fromList,fromDistinctAscList)
 import Data.IntMap.CharMap2(CharMap(..))
@@ -139,7 +139,7 @@ listTestInfo qt s = execState (helper qt) s
 -- processing Or.
 applyNullViews :: NullView -> QT -> QT
 applyNullViews [] win = win
-applyNullViews nvs win = foldl' (dominate win) qtlose (reverse $ cleanNullView nvs) where
+applyNullViews nvs win = List.foldl' (dominate win) qtlose (reverse $ cleanNullView nvs)
 
 -- This is used to prefer to view "win" through NullView.  Losing is
 -- replaced by the plain win.  This is employed by Star patterns to
@@ -147,7 +147,7 @@ applyNullViews nvs win = foldl' (dominate win) qtlose (reverse $ cleanNullView n
 -- skipping the NullView occurs if the match fails.
 preferNullViews :: NullView -> QT -> QT
 preferNullViews [] win = win
-preferNullViews nvs win = foldl' (dominate win) win (reverse $ cleanNullView nvs) where
+preferNullViews nvs win = List.foldl' (dominate win) win (reverse $ cleanNullView nvs)
 
 {-
 dominate is common to applyNullViews and preferNullViews above.

--- a/regex-tdfa.cabal
+++ b/regex-tdfa.cabal
@@ -1,6 +1,6 @@
 cabal-version:          2.0
 name:                   regex-tdfa
-version:                1.3.2.4
+version:                1.3.2.5
 
 build-Type:             Simple
 license:                BSD3
@@ -28,7 +28,7 @@ extra-source-files:
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8
@@ -48,7 +48,7 @@ source-repository head
 source-repository this
   type:                git
   location:            https://github.com/haskell-hvr/regex-tdfa.git
-  tag:                 v1.3.2.4
+  tag:                 v1.3.2.5
 
 flag force-O2
   default: False
@@ -148,11 +148,8 @@ test-suite regex-tdfa-unittest
   build-depends:        array
                       , base
                       , bytestring
-                      , containers
                       , filepath
-                      , mtl
                       , regex-base
-                      , text
 
   -- component-specific dependencies not inherited via 'regex-tdfa'
                       , directory          >= 1.1.0  && < 1.4
@@ -178,8 +175,7 @@ test-suite doctest
   main-is:        DocTestMain.hs
 
   build-depends:
-      base
-    , regex-tdfa
+      base             >= 4.9    && < 5
     , doctest-parallel >= 0.2.2
         -- doctest-parallel-0.2.2 is the first to filter out autogen-modules
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MonoLocalBinds             #-}
 
-#if __GLASGOW_HASKELL__ >= 902
+#if __GLASGOW_HASKELL__ >= 900
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 #endif
 


### PR DESCRIPTION
- **Fix #71: use `getSizeofMutualByteArray#`**
  

- **Fix redundant import warning for foldl'**
  

- **Bump to 1.3.2.5 and CHANGELOG**
  
Candidate: https://hackage.haskell.org/package/regex-tdfa-1.3.2.5/candidate'